### PR TITLE
Use last comment timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 os:
 - linux
 python:
-- '2.6'
 - '2.7'
 - '3.3'
 - '3.4'

--- a/recho/cli.py
+++ b/recho/cli.py
@@ -45,7 +45,7 @@ def get_last_seen():
     if not os.path.exists(TS_FILEPATH):
         last_seen = dt.utcnow()
     else:
-        with open(TS_FILEPATH, 'r') as r:
+        with open(TS_FILEPATH, 'r') as r:  # pylint: disable=C0103
             last_seen = dt.fromtimestamp(float(r.read()))
 
     return last_seen
@@ -61,13 +61,13 @@ def main():
     # Get last timestamp
     last_seen = get_last_seen()
 
-    # Get comments from reddit
-    activity = get_reddit_posts_since(args.redditor, last_seen)
+    # Get new comments and threads from reddit
+    new_posts = get_reddit_posts_since(args.redditor, last_seen)
 
-    if activity:
-        # Post posts to slack
-        post_to_slack(config['slack'], activity)
+    if new_posts:
+        # Post new comments and threads to slack
+        latest_timestamp = post_to_slack(config['slack'], new_posts)
 
-    # Write new timestamp
-    with open(TS_FILEPATH, 'w') as w:
-        w.write(str(dt.utcnow().timestamp()))
+        # Write new timestamp
+        with open(TS_FILEPATH, 'w') as w:  # pylint: disable=C0103
+            w.write(str(latest_timestamp.timestamp()))

--- a/recho/reddit.py
+++ b/recho/reddit.py
@@ -2,7 +2,7 @@ class UnsupportedSubmissionError(Exception):
     pass
 
 
-class RedditBase(object):
+class RedditBase(object):  # pylint: disable=R0903
     """ Base model for Reddit Post and Comment objects from Praw
     """
     def __init__(self, obj):

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 skipdist = True
-envlist = py3,lint
+envlist = py{27,33,34,35,36},lint
 
 [testenv]
 commands =
     py.test -s --cov recho --cov-report term-missing --cov-report html --cov-report xml --junitxml={envdir}/junit.xml tests []
 deps =
-    pytest>=2.6.4
+    pytest>=3.0
     pytest-cov>=1.8.1
 
 [testenv:lint]


### PR DESCRIPTION
 - Use the timestamp of the last comment posted to slack, rather than writing
   the current dt timestamp after each run.